### PR TITLE
Enum case alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AliasMacro
+
 Swift Macro for defining aliases for types, functions, or variables.
 
 <!-- # Badges -->
@@ -9,25 +10,13 @@ Swift Macro for defining aliases for types, functions, or variables.
 [![Github top language](https://img.shields.io/github/languages/top/p-x9/AliasMacro)](https://github.com/p-x9/AliasMacro/)
 
 ## Usage
+
 A macro that can be attached to a type, function or variable.
 
-### Class/Struct/Enum/Actor
-For example, the `ViewController` can also be referenced as a `VC` by writing the following.
-(If this macro is used for type, it is defined internally simply using `typealias`.)
-```swift
-@Alias("VC")
-class ViewContoroller: UIViewController {
-    /* --- */
-}
-
-/* ↓↓↓↓↓ */
-
-print(ViewContoroller.self) // => "ViewController"
-print(VC.self) // => "ViewController"
-```
-
 ### Variable
+
 You can define an alias for a variable as follows
+
 ```swift
 class SomeClass {
     @Alias("title")
@@ -43,8 +32,10 @@ print(title) // => "hello"
 ```
 
 ### Function/Method
+
 You can define an alias for a function as follows.
 In this way, you can call both `hello("aaa", at: Date())` and `こんにちは("aaa", at: Date())`.
+
 ```swift
 class SomeClass {
     @Alias("こんにちは")
@@ -63,17 +54,18 @@ someClass.こんにちは("aaa", at: Date()) // => "aaa"
 ```
 
 #### Customize Argument Label
+
 Argument labels can also be customized by separating them with ":".
 
 ```swift
 class SomeClass {
-    @Alias("こんにちは:いつ")
+    @Alias("こんにちは::いつ")
     func hello(_ text: String, at date: Date) {
         /* --- */
         print(text)
     }
 
-    @Alias("こんにちは2:_") // Omit argument labels
+    @Alias("こんにちは2:_:_") // Omit argument labels
     func hello2(_ text: String, at date: Date) {
         /* --- */
         print(text)
@@ -100,8 +92,69 @@ someClass.hello3("aaa", at: Date(), to: "you") // => "aaa"
 someClass.こんにちは3("aaa", at: Date(), 宛: "あなた") // => "aaa"
 ```
 
+### Enum Case
+
+You can define alias for enum case.
+
+For example, suppose we define the following.
+
+```swift
+enum Difficulty {
+    @Alias("beginner")
+    case easy
+
+    @Alias("normal")
+    case medium
+
+    @Alias("challenge")
+    case hard
+
+    @Alias("extreme")
+    case expert
+}
+```
+
+At this time, the macro is expanded as follows.
+
+```swift
+enum Difficulty {
+    case easy
+    case medium
+    case hard
+    case expert
+
+    static let beginner: Self = .easy
+    static let normal: Self = .medium
+    static let challenge: Self = .hard
+    static let extreme: Self = .expert
+}
+```
+
+### Class/Struct/Enum/Actor
+
+For example, the `ViewController` can also be referenced as a `VC` by writing the following.
+(If this macro is used for type, it is defined internally simply using `typealias`.)
+
+> **Warning**
+> `PeerMacro` with arbitrary specified in `names` cannot be used in global scope.
+> [Restrictions on arbitrary names](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md#restrictions-on-arbitrary-names)
+
+```swift
+@Alias("VC")
+class ViewContoroller: UIViewController {
+    /* --- */
+}
+
+/* ↓↓↓↓↓ */
+
+print(ViewContoroller.self) // => "ViewController"
+print(VC.self) // => "ViewController"
+```
+
 ### Multiple Aliases
+
 Multiple aliases can be defined by adding multiple macros as follows
+
 ```swift
 @Alias("hello")
 @Alias("こんにちは")
@@ -109,16 +162,21 @@ var text: String = "Hello"
 ```
 
 ### Specify Access Modifier of Alias
+
 You can specify an alias access modifier as follows.
+
 ```swift
 @Alias("hello", access: .public)
 private var text: String = "Hello"
 ```
 
 If set "inherit", it will inherit from the original definition.
+
 ```swift
 @Alias("hello", access: .inherit)
 private var text: String = "Hello"
 ```
+
 ## License
+
 AliasMacro is released under the MIT License. See [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ enum Difficulty {
 
     @Alias("extreme")
     case expert
+
+    @Alias("ultimate")
+    case master(level: Int)
 }
 ```
 
@@ -127,6 +130,10 @@ enum Difficulty {
     static let normal: Self = .medium
     static let challenge: Self = .hard
     static let extreme: Self = .expert
+
+    static func ultimate(level: Int) -> Self {
+        .master(level)
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ enum Difficulty {
     case medium
     case hard
     case expert
-    case master
+    case master(level: Int)
 
     static let beginner: Self = .easy
     static let normal: Self = .medium

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ enum Difficulty {
     case medium
     case hard
     case expert
+    case master
 
     static let beginner: Self = .easy
     static let normal: Self = .medium

--- a/Sources/AliasPlugin/AliasMacro.swift
+++ b/Sources/AliasPlugin/AliasMacro.swift
@@ -220,15 +220,55 @@ extension AliasMacro {
             return []
         }
 
-        let aliasDecl: DeclSyntax = "static let \(raw: arguments.alias): Self = .\(element.name)"
+        if let parameterClause = element.parameterClause {
+//            var argNames: [TokenSyntax] = []
+//            let parameters = parameterClause.parameters
+//                .enumerated()
+//                .map {
+//                    if let firstName = $1.firstName, $1.secondName == nil {
+//                        argNames.append(firstName)
+//                        return "\(firstName.trimmed): \($1.type)"
+//                    } else if let firstName = $1.firstName, let secondName = $1.secondName {
+//                        argNames.append(secondName)
+//                        return "\(firstName.trimmed) \(secondName.trimmed): \($1.type)"
+//                    } else {
+//                        argNames.append(.identifier("arg\($0)"))
+//                        return "_ arg\($0): \($1.type.trimmed)"
+//                    }
+//                }
+//                .joined(separator: ", ")
+            let parameters = parameterClause.parameters
+            let functionParameters = parameters.functionParameterListSyntax.map {
+                "\($0)"
+            }.joined(separator: ", ")
+            let functionArguments = parameters.labeledExprListSyntax.map {
+                "\($0)"
+            }.joined(separator: ", ")
 
-        if let accessModifier = arguments.accessControl?.modifier {
+            let aliasDecl: DeclSyntax = """
+            static func \(raw: arguments.alias)(\(raw: functionParameters)) -> Self {
+                .\(element.name)(\(raw: functionArguments))
+            }
+            """
+            if let accessModifier = arguments.accessControl?.modifier {
+                return [
+                    "\(raw: accessModifier) \(aliasDecl)"
+                ]
+            }
             return [
-                "\(raw: accessModifier) \(aliasDecl)"
+                aliasDecl
+            ]
+        } else {
+            let aliasDecl: DeclSyntax = "static let \(raw: arguments.alias): Self = .\(element.name)"
+
+            if let accessModifier = arguments.accessControl?.modifier {
+                return [
+                    "\(raw: accessModifier) \(aliasDecl)"
+                ]
+            }
+            return [
+                aliasDecl
             ]
         }
-        return [
-            aliasDecl
-        ]
     }
 }

--- a/Sources/AliasPlugin/AliasMacroDiagnostic.swift
+++ b/Sources/AliasPlugin/AliasMacroDiagnostic.swift
@@ -13,6 +13,8 @@ public enum AliasMacroDiagnostic {
     case unsupportedDeclaration
     case specifyTypeExplicitly
     case multipleVariableDeclarationIsNotSupported
+    case enumCaseCannotInheritAccessModifiers
+    case multipleEnumCaseDeclarationIsNotSupported
 }
 
 extension AliasMacroDiagnostic: DiagnosticMessage {
@@ -29,6 +31,14 @@ extension AliasMacroDiagnostic: DiagnosticMessage {
         case .multipleVariableDeclarationIsNotSupported:
             return """
             Multiple variable declaration in one statement is not supported.
+            """
+        case .enumCaseCannotInheritAccessModifiers:
+            return """
+            Enum case has no access modifier and cannot inherit.
+            """
+        case .multipleEnumCaseDeclarationIsNotSupported:
+            return """
+            Multiple enum case declaration in one statement is not supported.
             """
         }
     }

--- a/Sources/AliasSupport/Extesnsion/AttributeListSyntax+.swift
+++ b/Sources/AliasSupport/Extesnsion/AttributeListSyntax+.swift
@@ -17,6 +17,6 @@ extension AttributeListSyntax {
             }
             return true
         }
-        return .init(attributes)
+        return attributes
     }
 }

--- a/Sources/AliasSupport/Extesnsion/EnumCaseParameterListSyntax+.swift
+++ b/Sources/AliasSupport/Extesnsion/EnumCaseParameterListSyntax+.swift
@@ -1,0 +1,42 @@
+//
+//  EnumCaseParameterListSyntax+.swift
+//
+//
+//  Created by p-x9 on 2023/11/07.
+//  
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension EnumCaseParameterListSyntax {
+    package var functionParameterListSyntax: FunctionParameterListSyntax {
+        let parameters: [FunctionParameterSyntax] = self.enumerated()
+            .map {
+                if let firstName = $1.firstName, $1.secondName == nil {
+                    return "\(firstName.trimmed): \($1.type)"
+                } else if let firstName = $1.firstName, let secondName = $1.secondName {
+                    return "\(firstName.trimmed) \(secondName.trimmed): \($1.type)"
+                } else {
+                    return "_ arg\(raw: $0): \($1.type.trimmed)"
+                }
+            }
+        return .init(parameters)
+    }
+
+    package var labeledExprListSyntax: LabeledExprListSyntax {
+        let arguments: [LabeledExprSyntax] = self.enumerated()
+            .map {
+                if let firstName = $1.firstName, $1.secondName == nil {
+                    return .init(label: "\(firstName.trimmed)",
+                                 expression: ExprSyntax("\(firstName.trimmed)"))
+                } else if let firstName = $1.firstName, let secondName = $1.secondName {
+                    return .init(label: "\(firstName.trimmed)",
+                                 expression: ExprSyntax("\(secondName.trimmed)"))
+                } else {
+                    return .init(expression: ExprSyntax("arg\(raw: $0)"))
+                }
+            }
+        return .init(arguments)
+    }
+}

--- a/Tests/AliasTests/AliasTests.swift
+++ b/Tests/AliasTests/AliasTests.swift
@@ -212,6 +212,28 @@ final class AliasTests: XCTestCase {
         )
     }
 
+    func testEnumCaseAliasWithParameters() throws {
+        assertMacroExpansion(
+            """
+            enum ItemType {
+                @Alias("HEAD")
+                case header(String, subtitle: String, index: Int)
+            }
+            """,
+            expandedSource:
+            """
+            enum ItemType {
+                case header(String, subtitle: String, index: Int)
+
+                static func HEAD(_ arg0: String, subtitle: String, index: Int) -> Self {
+                    .header(arg0, subtitle: subtitle, index: index)
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
     func testEnumCaseAliasWithAccessModifier() throws {
         assertMacroExpansion(
             """

--- a/Tests/AliasTests/AliasTests.swift
+++ b/Tests/AliasTests/AliasTests.swift
@@ -192,6 +192,46 @@ final class AliasTests: XCTestCase {
         )
     }
 
+    func testEnumCaseAlias() throws {
+        assertMacroExpansion(
+            """
+            enum ItemType {
+                @Alias("HEAD")
+                case header
+            }
+            """,
+            expandedSource:
+            """
+            enum ItemType {
+                case header
+
+                static let HEAD: Self = .header
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testEnumCaseAliasWithAccessModifier() throws {
+        assertMacroExpansion(
+            """
+            enum ItemType {
+                @Alias("HEAD", access: .public)
+                case header
+            }
+            """,
+            expandedSource:
+            """
+            enum ItemType {
+                case header
+
+                public static let HEAD: Self = .header
+            }
+            """,
+            macros: macros
+        )
+    }
+
     func testMultipleTypeAlias() throws {
         assertMacroExpansion(
             """
@@ -273,6 +313,60 @@ final class AliasTests: XCTestCase {
                         .message,
                     line: 1,
                     column: 1
+                )
+             ],
+             macros: macros
+        )
+    }
+
+    func testDiagnosticsEnumCaseInheritAccessModifier() throws {
+        assertMacroExpansion(
+             """
+             enum ItemType {
+                @Alias("HEAD", access: .inherit)
+                case header
+             }
+             """,
+             expandedSource:
+             """
+             enum ItemType {
+                case header
+             }
+             """,
+             diagnostics: [
+                DiagnosticSpec(
+                    message: AliasMacroDiagnostic
+                        .enumCaseCannotInheritAccessModifiers
+                        .message,
+                    line: 2,
+                    column: 4
+                )
+             ],
+             macros: macros
+        )
+    }
+
+    func testDiagnosticsMultipleEnumCase() throws {
+        assertMacroExpansion(
+             """
+             enum ItemType {
+                @Alias("HEAD", access: .public)
+                case header, footer
+             }
+             """,
+             expandedSource:
+             """
+             enum ItemType {
+                case header, footer
+             }
+             """,
+             diagnostics: [
+                DiagnosticSpec(
+                    message: AliasMacroDiagnostic
+                        .multipleEnumCaseDeclarationIsNotSupported
+                        .message,
+                    line: 3,
+                    column: 9
                 )
              ],
              macros: macros


### PR DESCRIPTION
```swift
enum Difficulty {
    @Alias("beginner")
    case easy

    @Alias("normal")
    case medium

    @Alias("challenge")
    case hard

    @Alias("extreme")
    case expert

    @Alias("ultimate")
    case master(level: Int)
}
```

At this time, the macro is expanded as follows.

```swift
enum Difficulty {
    case easy
    case medium
    case hard
    case expert
    case master

    static let beginner: Self = .easy
    static let normal: Self = .medium
    static let challenge: Self = .hard
    static let extreme: Self = .expert
    static func ultimate(level: Int) -> Self {
        .master(level)
    }
}
```