### PR TITLE
Modified to omit type specification when using literal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
             name: "AliasTests",
             dependencies: [
                 "Alias",
+                "AliasPlugin",
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),

--- a/Tests/AliasTests/AliasTests.swift
+++ b/Tests/AliasTests/AliasTests.swift
@@ -48,6 +48,29 @@ final class AliasTests: XCTestCase {
         )
     }
 
+    func testVariableAliasWithLiteral() throws {
+        assertMacroExpansion(
+             """
+             @Alias("newText", access: .inherit)
+             fileprivate var string = "text"
+             """,
+             expandedSource:
+             """
+             fileprivate var string = "text"
+
+             fileprivate var newText: Swift.String {
+                 set {
+                     string  = newValue
+                 }
+                 get {
+                     string
+                 }
+             }
+             """,
+             macros: macros
+        )
+    }
+
     func testFunctionAlias() throws {
         assertMacroExpansion(
             """
@@ -342,19 +365,19 @@ final class AliasTests: XCTestCase {
         assertMacroExpansion(
              """
              @Alias("newText", access: .inherit)
-             fileprivate var string = "text"
+             fileprivate var string = String()
              """,
              expandedSource:
              """
-             fileprivate var string = "text"
+             fileprivate var string = String()
              """,
              diagnostics: [
                 DiagnosticSpec(
                     message: AliasMacroDiagnostic
                         .specifyTypeExplicitly
                         .message,
-                    line: 1,
-                    column: 1
+                    line: 2,
+                    column: 17
                 )
              ],
              macros: macros


### PR DESCRIPTION
```swift
@Alias("text", access: .inherit)
var hello = ""

@Alias("floatNum", access: .inherit)
var floatNumber = 0.0

@Alias("intNum", access: .inherit)
var integerNumber = 0

@Alias("isActive", access: .inherit)
var isOn = false
```